### PR TITLE
GNAF bulk geocoder

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,14 @@
 Change Log
 ==========
 
+### Next release
+
+* Now compatible with case change in Terria GnafApi, and also adds Australia-specific bulk address geocoder so that addresses in csvs can be shown on the map.
+
 ### 2016-07-15
 
 * Catalog (init) files can now be stored as .ejs files in /datasources, rendered by the EJS templating library. See comments in gulpfile.js.
+
 ### 2016-06-15
 
 * Added a prominent link to the preview of the new UI.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ import OgrCatalogItem from 'terriajs/lib/Models/OgrCatalogItem';
 import raiseErrorToUser from 'terriajs/lib/Models/raiseErrorToUser';
 import registerAnalytics from 'terriajs/lib/Models/registerAnalytics';
 import registerCatalogMembers from 'terriajs/lib/Models/registerCatalogMembers';
+import GnafAddressConverter from 'terriajs/lib/Map/GnafAddressConverter.js';
 import registerCustomComponentTypes from 'terriajs/lib/ReactViews/Custom/registerCustomComponentTypes';
 import registerKnockoutBindings from 'terriajs/lib/Core/registerKnockoutBindings';
 import Terria from 'terriajs/lib/Models/Terria';
@@ -30,7 +31,7 @@ import updateApplicationOnMessageFromParentWindow from 'terriajs/lib/ViewModels/
 import ViewState from 'terriajs/lib/ReactViewModels/ViewState';
 import BingMapsSearchProviderViewModel from 'terriajs/lib/ViewModels/BingMapsSearchProviderViewModel.js';
 import GazetteerSearchProviderViewModel from 'terriajs/lib/ViewModels/GazetteerSearchProviderViewModel.js';
-import GNAFSearchProviderViewModel from 'terriajs/lib/ViewModels/GNAFSearchProviderViewModel.js';
+import GnafSearchProviderViewModel from 'terriajs/lib/ViewModels/GnafSearchProviderViewModel.js';
 
 import render from './lib/Views/render';
 
@@ -48,6 +49,7 @@ registerCatalogMembers();
 registerAnalytics();
 
 terriaOptions.analytics = new GoogleAnalytics();
+terriaOptions.batchGeocoder = new GnafAddressConverter();
 
 // Construct the TerriaJS application, arrange to show errors to the user, and start it up.
 var terria = new Terria(terriaOptions);
@@ -95,7 +97,7 @@ terria.start({
                 key: configuration.bingMapsKey
             }),
             new GazetteerSearchProviderViewModel({terria}),
-            new GNAFSearchProviderViewModel({terria})
+            new GnafSearchProviderViewModel({terria})
         ];
 
         // Automatically update Terria (load new catalogs, etc.) when the hash part of the URL changes.


### PR DESCRIPTION
1. Changes case of GNAF -> Gnaf in line with recent terria changes.
2. Adds GNAF address converter so that csv files that contain addresses can be geocoded and displayed on map (Australian addresses only).

Waiting on:
- _msearch to be publicly accessible
- https://github.com/TerriaJS/terriajs/pull/1755
