### PR TITLE
Fix TIND

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 2016-08-25
+
+* Added `"ungroupedTitle": null` to `tind.json` to fix the Telecommunications in New Developments embedded map.
+
 ### 2016-08-15b
 
 * Updated to [TerriaJS](https://github.com/TerriaJS/terriajs) 4.2.1.  Significant changes relevant to NationalMap users include:

--- a/buildprocess/webpack.config.js
+++ b/buildprocess/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = function(devMode, hot) {
         entry: './index.js',
         output: {
             path: 'wwwroot/build',
-            filename: 'TerriaMap.js',
+            filename: 'nationalmap.js',
             // work around chrome needing the full URL when using sourcemaps (http://stackoverflow.com/questions/34133808/webpack-ots-parsing-error-loading-fonts/34133809#34133809)
             publicPath: hot ? 'http://localhost:3003/build/' : 'build/',
             sourcePrefix: '' // to avoid breaking multi-line string literals by inserting extra tabs.
@@ -47,11 +47,11 @@ module.exports = function(devMode, hot) {
                     include: [path.resolve(__dirname, '..', 'lib')],
                     loader: hot ?
                         require.resolve('style-loader') + '!' +
-                        require.resolve('css-loader') + '?sourceMap&modules&camelCase&localIdentName=tm-[name]__[local]&importLoaders=2!' +
+                        require.resolve('css-loader') + '?sourceMap&modules&camelCase&localIdentName=nm-[name]__[local]&importLoaders=2!' +
                         require.resolve('resolve-url-loader') + '?sourceMap!' +
                         require.resolve('sass-loader') + '?sourceMap'
                      : ExtractTextPlugin.extract(
-                        require.resolve('css-loader') + '?sourceMap&modules&camelCase&localIdentName=tm-[name]__[local]&importLoaders=2!' +
+                        require.resolve('css-loader') + '?sourceMap&modules&camelCase&localIdentName=nm-[name]__[local]&importLoaders=2!' +
                         require.resolve('resolve-url-loader') + '?sourceMap!' +
                         require.resolve('sass-loader') + '?sourceMap',
                         {
@@ -67,7 +67,7 @@ module.exports = function(devMode, hot) {
                     'NODE_ENV': devMode ? '"development"' : '"production"'
                 }
             }),
-            new ExtractTextPlugin("TerriaMap.css", {disable: hot, ignoreOrder: true})
+            new ExtractTextPlugin("nationalmap.css", {disable: hot, ignoreOrder: true})
         ]
     };
 

--- a/devserverconfig.json
+++ b/devserverconfig.json
@@ -1,8 +1,5 @@
 {
-    # Port to listen on.
     "port": 3001,
-
-    # List of domains which our server is willing to proxy for. Subdomains are included automatically.
     "allowProxyFor" : [
         "nicta.com.au",
         "gov.au",

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ import updateApplicationOnMessageFromParentWindow from 'terriajs/lib/ViewModels/
 import ViewState from 'terriajs/lib/ReactViewModels/ViewState';
 import BingMapsSearchProviderViewModel from 'terriajs/lib/ViewModels/BingMapsSearchProviderViewModel.js';
 import GazetteerSearchProviderViewModel from 'terriajs/lib/ViewModels/GazetteerSearchProviderViewModel.js';
-import GNAFSearchProviderViewModel from 'terriajs/lib/ViewModels/GNAFSearchProviderViewModel.js';
+import GnafSearchProviderViewModel from 'terriajs/lib/ViewModels/GnafSearchProviderViewModel.js';
 
 import render from './lib/Views/render';
 
@@ -95,7 +95,7 @@ terria.start({
                 key: configuration.bingMapsKey
             }),
             new GazetteerSearchProviderViewModel({terria}),
-            new GNAFSearchProviderViewModel({terria})
+            new GnafSearchProviderViewModel({terria})
         ];
 
         // Automatically update Terria (load new catalogs, etc.) when the hash part of the URL changes.

--- a/wwwroot/init/tind.json
+++ b/wwwroot/init/tind.json
@@ -26,7 +26,8 @@
             "isOpen": true,
             "itemProperties": {
                 "cacheDuration": "1d"
-            }
+            },
+            "ungroupedTitle": null
         }
     ]
 }


### PR DESCRIPTION
This builds on #305 so merge that first.

The Telecommunications in New Developments page integrates NationalMap:
https://www.communications.gov.au/what-we-do/internet/competition-broadband/telecommunications-new-developments-map

Unfortunately, we broke it recently by changing the default behavior for CKAN catalog items that are not in any groups on the CKAN server.  Previously they were placed directly under the CKAN group.  Now, they are (by default) placed inside a "No Group" group.  This change means that share URLs assuming that old location are now broken.

The old `CkanCatalogGroup` behavior can be restored by setting the `ungroupedTitle` property to `null` in the init file, which is what this PR does.