### PR TITLE
Add aus_code to aliases for aus regiontype

### DIFF
--- a/wwwroot/data/regionMapping.json
+++ b/wwwroot/data/regionMapping.json
@@ -798,7 +798,8 @@
             "server": "http://geoserver.nationalmap.nicta.com.au/region_map/ows",
             "regionProp": "AUS_CODE",
             "aliases": [
-                "aus"
+                "aus",
+                "aus_code"
             ],
             "regionIdsFile": "data/regionids/region_map-FID_AUS_2011_AUST_AUS_CODE.json"
         }


### PR DESCRIPTION
This makes the `aus` region consistent with `sa4`, `lga` etc which all have a `_code` alias.
Makes the SDMX-JSON catalog item more streamlined.