### PR TITLE
Add region and geojson WPS tests

### DIFF
--- a/wwwroot/init/test.json
+++ b/wwwroot/init/test.json
@@ -330,7 +330,7 @@
             {
               "name": "GeoJsonTest",
               "type": "wps",
-              "url": "http://sparrow.terria.io:5001?service=wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
               "identifier": "geojson_test",
               "opacity" : 0.6,
               "ignoreUnknownTileErrors": true

--- a/wwwroot/init/test.json
+++ b/wwwroot/init/test.json
@@ -320,6 +320,22 @@
               "ignoreUnknownTileErrors": true
             },
             {
+              "name": "RegionTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001/wps?service=wps",
+              "identifier": "region_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
+              "name": "GeoJsonTest",
+              "type": "wps",
+              "url": "http://sparrow.terria.io:5001?service=wps",
+              "identifier": "geojson_test",
+              "opacity" : 0.6,
+              "ignoreUnknownTileErrors": true
+            },
+            {
               "name": "ContextTest",
               "type": "wps",
               "url": "http://sparrow.terria.io:5001/wps?service=wps",


### PR DESCRIPTION
Two more manual WPS tests added. At time of writing, region relies on an open pull request, and geojson relies on a branch not yet pushed, but I see no reason not to add them now. 