### PR TITLE
Replace references in HTML pages to "The National Map"

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -8,12 +8,12 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 
-Portions of the National Map use the following copyrighted material, the use of which is hereby acknowledged.
+Portions of NationalMap use the following copyrighted material, the use of which is hereby acknowledged.
 
 Third-Party Code
 ================
 
-National Map includes the following third-party code.
+NationalMap includes the following third-party code.
 
 ###  Cesium
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-National Map
+NationalMap
 ============
 
 [![Build Status](https://travis-ci.org/TerriaJS/nationalmap.svg?branch=master)](https://travis-ci.org/TerriaJS/nationalmap)
 
-The [National Map](http://nationalmap.gov.au) is a website for map-based access to Australian spatial data from government agencies. It is an initiative of the Australian Commonwealth Government's [Department of the Prime Minister and Cabinet](http://www.dpmc.gov.au/) and the software has been developed by [Data61](http://www.csiro.au/en/Research/D61) (formerly NICTA) working closely with the Department of the Prime Minister and Cabinet, [Geoscience Australia](http://www.ga.gov.au/) and other government agencies.
+[NationalMap](http://nationalmap.gov.au) is a website for map-based access to Australian spatial data from government agencies. It is an initiative of the Australian Commonwealth Government's [Department of the Prime Minister and Cabinet](http://www.dpmc.gov.au/) and the software has been developed by [Data61](http://www.csiro.au/en/Research/D61) (formerly NICTA) working closely with the Department of the Prime Minister and Cabinet, [Geoscience Australia](http://www.ga.gov.au/) and other government agencies.
 
-The National Map is designed to:
+NationalMap is designed to:
 * Provide easy access to authoritative and other spatial data to government, business and public
 * Facilitate the opening of data by federal, state and local government bodies
 * Provide an open framework of geospatial data services that supports commercial and community innovation
@@ -14,6 +14,6 @@ The National Map is designed to:
 NationalMap is powered by [TerriaJS](https://github.com/TerriaJS/TerriaJS), a free, open source geospatial catalog viewer. The content is maintained in [NationalMap-Catalog](https://github.com/TerriaJS/NationalMap-Catalog).
 
 ### Want to make your own Terria Map? ###
-Please don't clone **this** repo. Instead, start your map from https://github.com/TerriaJS/TerriaMap, which is maintained as a starting point for third-party maps, without the NationalMap branding.
+Please don't clone **this** repo. Instead, start your map from https://github.com/TerriaJS/TerriaMap, which is maintained as a starting point for third-party maps, without NationalMap branding.
 
 See the [TerriaMap documentation](http://terria.io/Documentation/) for more detailed information about Terria and how to build and run it.

--- a/ckanext-cesiumpreview/README.md
+++ b/ckanext-cesiumpreview/README.md
@@ -1,7 +1,7 @@
-National Map CKAN Preview plugin
+NationalMap CKAN Preview plugin
 ================================
 
-A plugin to CKAN to use National Map as a previewer for data.gov.au.
+A plugin to CKAN to use NationalMap as a previewer for data.gov.au.
 
 The goal of this project is to be open source when it releases, so all work
  should be carried out with that in mind.
@@ -15,7 +15,7 @@ more information about how to get this working with CKAN
 
 #### From Git Repository ####
 * Log in to github
-* Fork the [NationalMap](https://github.com/NICTA/nationalmap.git) repo into your personal github account using the github UI.
+* Fork [NationalMap](https://github.com/NICTA/nationalmap.git) repo into your personal github account using the github UI.
 * Clone your forks locally so data is inside subspace at root level e.g.
 
 

--- a/wwwroot/404.html
+++ b/wwwroot/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>The NationalMap - not found</title>
+        <title>NationalMap - not found</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="/public/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="/public/css/custom.css" rel="stylesheet" type="text/css" media="all"/>
@@ -33,10 +33,10 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
-            <li class="active"><a href="about.html">About National Map</a></li>
+            <li class="active"><a href="about.html">About NationalMap</a></li>
             <li ><a href="help/howto.html">Help &amp; FAQ</a></li>
             <li ><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au">Launch NationalMap</a></li>
         </ul>
 
         </div>

--- a/wwwroot/500.html
+++ b/wwwroot/500.html
@@ -33,10 +33,10 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
-            <li class="active"><a href="about.html">About National Map</a></li>
+            <li class="active"><a href="about.html">About NationalMap</a></li>
             <li ><a href="help/howto.html">Help &amp; FAQ</a></li>
             <li ><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au">Launch NationalMap</a></li>
         </ul>
 
         </div>

--- a/wwwroot/about.html
+++ b/wwwroot/about.html
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li class="active"><a href="#">About the National Map</a></li>
+            <li class="active"><a href="#">About NationalMap</a></li>
             <li><a href="help/help.html">Help & FAQ</a></li>
             <li><a href="help/privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -63,9 +63,9 @@
     <div class="row">
     <div class="col-sm-9">
 
-    <h1>About the NationalMap</h2>
+    <h1>About NationalMap</h2>
 
-      <p>The <strong>NationalMap</strong> is a website for map-based access to spatial data from Australian government agencies.
+      <p><strong>NationalMap</strong> is a website for map-based access to spatial data from Australian government agencies.
       It is an initiative of the Department of Communications and the Arts now currently managed by the Department of the Prime Minister and Cabinet and the software has been developed by Data61 working closely with the Department of Communications and the Arts, Geoscience Australia and other government agencies.</p>
 
       <!-- 4:3 aspect ratio -->
@@ -73,20 +73,20 @@
         <iframe class="embed-responsive-item" src="//www.youtube-nocookie.com/embed/gsEAq0x0xh4?rel=0"></iframe>
       </div>
 
-      <p>The <strong>NationalMap</strong> is a fully open architecture. When you access data through it, you are typically
+      <p><strong>NationalMap</strong> is a fully open architecture. When you access data through it, you are typically
       accessing the data directly from the government department or agency which is the custodian of that data.</p>
 
-      <p>The <strong>NationalMap</strong>...</p>
+      <p><strong>NationalMap</strong>...</p>
       <ul>
          <li>provides easy access to authoritative and other spatial data to government, business and the public</li>
          <li>facilitates the opening of data by federal, state and local government bodies</li>
          <li>provides an open framework of geospatial data services that supports commercial and community innovation</li>
       </ul>
 
-      <p>To see what data is available on the NationalMap, refer to the Data Catalogue in the
+      <p>To see what data is available on NationalMap, refer to the Data Catalogue in the
       <a href="http://nationalmap.gov.au/">NationalMap</a> itself. Click the <b>Data Catalogue</b> tab and expand the Data Set group names.</p>
 
-      <h2>How to use the NationalMap</h2>
+      <h2>How to use NationalMap</h2>
 
       <p>Just go to <a href="http://nationalmap.gov.au/">http://nationalmap.gov.au/</a>. Most operations are obvious,
       but you can click the <a href="help/help.html">Help and FAQs</a> button near the top of this page for specific instructions.</p>
@@ -97,22 +97,22 @@
       <h2>Contributing Data to NationalMap</h2>
 
       <p>Spatial data sets which are placed on <a href="http://data.gov.au/" target="_blank">data.gov.au</a> using supported data formats and protocols (such as WMS) will
-      automatically be included in the NationalMap. See the <a href="help/help.html">How To...</a> page for more information.</p>
+      automatically be included in NationalMap. See the <a href="help/help.html">How To...</a> page for more information.</p>
 
-      <p>Australian government agencies that wish to find out more information about contributing data sets to the NationalMap
+      <p>Australian government agencies that wish to find out more information about contributing data sets to NationalMap
       should email <a href="mailto:data@pmc.gov.au">data@pmc.gov.au</a> with their questions.
-      Typically, the NationalMap does not store the data itself, but refers to the data servers of the data contributors,
+      Typically, NationalMap does not store the data itself, but refers to the data servers of the data contributors,
       directly taking that data and presenting it overlaid over a map. Therefore, agencies providing data directly must have the data
       available via an online server using a standard protocol.</p>
 
       <h2>NationalMap Software</h2>
 
-      <p>The NationalMap is Open Source software available as a
+      <p>NationalMap is Open Source software available as a
       <a href="https://github.com/NICTA/nationalmap" target="_blank">Github project</a>. The core platform, <a href="https://github.com/TerriaJS/terriajs" target="_blank">TerriaJS</a>, was initially
-      developed by Data61 for the NationalMap, but has subsequently been used for other projects. It has been made available
+      developed by Data61 for NationalMap, but has subsequently been used for other projects. It has been made available
       to assist with the development of other spatial data viewing applications.</p>
 
-      <p>The NationalMap core software is licensed under the Apache License, Version 2.0 (the "License"). You may not use the source code files
+      <p>NationalMap core software is licensed under the Apache License, Version 2.0 (the "License"). You may not use the source code files
       except in compliance with the License. You may obtain a copy of the License at
       <a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank">http://www.apache.org/licenses/LICENSE-2.0</a>.
       Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
@@ -121,7 +121,7 @@
 
       <h2>Additional Open Source Software Used</h2>
 
-      <p>In developing the NationalMap, Data61 has used open source software and contributed back to it.  NationalMap leverages these
+      <p>In developing NationalMap, Data61 has used open source software and contributed back to it.  NationalMap leverages these
       excellent open source libraries:</p>
 
       <ul>
@@ -132,13 +132,13 @@
       <p>The <a href="https://github.com/NICTA/nationalmap/blob/master/LICENSE.md">complete list</a> is available with the <a href="https://github.com/NICTA/nationalmap">NationalMap source code</a></p>
 
       <h2><a class="anchor" name="terms"></a>Terms &amp; Conditions</h2>
-      <p>The information displayed on the NationalMap is for general informational purposes only, and is not
+      <p>The information displayed on NationalMap is for general informational purposes only, and is not
       intended to provide any commercial, financial, or legal advice. Any information in connection with
-      the NationalMap may not be appropriate to your individual needs.  You must  exercise your own
-      independent, skill, care and judgment with respect to how you use the information displayed on the
-      National Map.<p>
+      NationalMap may not be appropriate to your individual needs.  You must  exercise your own
+      independent, skill, care and judgment with respect to how you use the information displayed on 
+      NationalMap.<p>
 
-      <p>As a condition of using the NationalMap, you must comply with all applicable laws, regulations and
+      <p>As a condition of using NationalMap, you must comply with all applicable laws, regulations and
       third party rights (including, without limitation, laws regarding the import or export of data or
       software, privacy and local laws). You must not use NationalMap to encourage or promote illegal
       activity or violation of third party rights. Some parts of NationalMap (like the URL shortening
@@ -147,26 +147,26 @@
       <p>In any important matter, you should seek professional advice relevant to your own
       circumstances.</p>
 
-      <p>The information displayed on the NationalMap was consolidated by the Department of the Prime Minister and Cabinet.</p>
+      <p>The information displayed on NationalMap was consolidated by the Department of the Prime Minister and Cabinet.</p>
 
       <p>The Department, Data61 and Geoscience Australia (“We”) make no representations or warranties
-      regarding the accuracy or completeness of any content or the product in connection with the
+      regarding the accuracy or completeness of any content or the product in connection with 
       NationalMap. We disclaim all responsibility and all liability (including without limitation, liability in
       negligence, for errors or omissions) for all expenses, loss, damage and costs which you might incur
-      as a result of the information displayed on the NationalMap and your use of it.</p>
+      as a result of the information displayed on NationalMap and your use of it.</p>
 
-      <p>The NationalMap must not be used for navigation or precise spatial analysis or for any activities
-      where the use or failure of the NationalMap could lead to death, personal injury, or environmental damage
+      <p>NationalMap must not be used for navigation or precise spatial analysis or for any activities
+      where the use or failure of NationalMap could lead to death, personal injury, or environmental damage
       (such as the operation of nuclear facilities, air traffic control, or life support systems).</p>
 
       <h3>Access to data:</h3>
-      <p>Any information provided by data custodians displayed on the NationalMap is provided as is and on
+      <p>Any information provided by data custodians displayed on NationalMap is provided as is and on
       the understanding that the respective data custodian is not responsible for, nor guarantees the
       timeliness, accuracy or completeness of that information. If you intend to rely on any information
-      displayed on the NationalMap or data.gov.au, then you must apply in writing to the respective data
+      displayed on NationalMap or data.gov.au, then you must apply in writing to the respective data
       custodian for further authorisation.</p>
 
-      <p>You acknowledge that your use of the NationalMap or data.gov.au means that you have provided
+      <p>You acknowledge that your use of NationalMap or data.gov.au means that you have provided
       your acceptance of these terms and conditions.</p>
 
 

--- a/wwwroot/about.html
+++ b/wwwroot/about.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../favicon.ico">
 
-    <title>The National Map - About</title>
+    <title>About NationalMap</title>
 
     <!-- Bootstrap core CSS -->
     <link href="help/css/bootstrap.min.css" rel="stylesheet">

--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -9,11 +9,11 @@
         "googleAnalyticsKey": null,
         "googleAnalyticsOptions": null,
         "disclaimer": {
-            "text": "Disclaimer: The NationalMap must not be used for navigation or precise spatial analysis",
+            "text": "Disclaimer: NationalMap must not be used for navigation or precise spatial analysis",
             "url": "about.html"
         },
         "printDisclaimer":{
-            "text":"The Department, Data61 and Geoscience Australia (“We”) make no representations or warranties regarding the accuracy or completeness of any content or the product in connection with the NationalMap. We disclaim all responsibility and all liability (including without limitation, liability in negligence, for errors or omissions) for all expenses, loss, damage and costs which you might incur as a result of the information displayed on the NationalMap and your use of it. The NationalMap must not be used for navigation or precise spatial analysis.",
+            "text":"The Department, Data61 and Geoscience Australia (“We”) make no representations or warranties regarding the accuracy or completeness of any content or the product in connection with NationalMap. We disclaim all responsibility and all liability (including without limitation, liability in negligence, for errors or omissions) for all expenses, loss, damage and costs which you might incur as a result of the information displayed on NationalMap and your use of it. NationalMap must not be used for navigation or precise spatial analysis.",
             "url": "#"
         },
         "developerAttribution": {

--- a/wwwroot/help/data-catalogue.html
+++ b/wwwroot/help/data-catalogue.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Help & FAQ - Data Catalogue</title>
+    <title>NationalMap - Help & FAQ - Data Catalogue</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li class="active"><a href="help.html">Help & FAQ</a></li>
             <li><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -68,11 +68,11 @@
 
         <h4 class="nav-header">How to...</h4>
         <ul class="how-to">
-          <li><a href="help.html">Get started with the National Map</a></li>
+          <li><a href="help.html">Get started with NationalMap</a></li>
           <li><a href="help.html#feature-info">Find out about a displayed feature</a></li>
           <li><a href="help.html#add-data">Display my own spatial data</a></li>
-          <li><a href="help.html#share">Share my National Map view</a></li>
-          <li><a href="help.html#contribute">Contribute Data Sets to the National Map</a></li>
+          <li><a href="help.html#share">Share my NationalMap view</a></li>
+          <li><a href="help.html#contribute">Contribute Data Sets to NationalMap</a></li>
         </ul>
 
         <h4 class="nav-header">Key Features</h4>
@@ -84,8 +84,8 @@
 
         <h4 class="nav-header">Frequently Asked Questions</h4>
         <ul class="faq">
-          <li><a href="faq.html">National Map Operation</a></li>
-          <li><a href="faq.html#nm-systemdata">National Map system and data</a></li>
+          <li><a href="faq.html">NationalMap Operation</a></li>
+          <li><a href="faq.html#nm-systemdata">NationalMap system and data</a></li>
           <li><a href="faq.html#nm-reportingissues">Reporting issues</a></li>
         </ul>
 
@@ -101,7 +101,7 @@
 
       <p>A wealth of spatial data has been made available though NationalMap, all of which can be accessed via the Data Catalogue. To launch the Data Catalogue, click the <strong>Add Data</strong> button in the left hand panel opposite the map.</p>
 
-      <p>Data sets displayed in the Data Catalogue are directly referenced from data.gov.au or from a server provided by the relevant department or agency. The NationalMap does not store any of the data it serves. For example, if you access data relating to broadband availability and quality, you are accessing that data directly from the Department of Communications and the Arts. When you access data relating to surface geology, it is accessed directly from Geoscience Australia. If you access data relating to water, it is typically coming directly from the Bureau of Meteorology. The NationalMap itself does not store any data - it provides a map-based view of data that is stored by a growing number of government bodies.
+      <p>Data sets displayed in the Data Catalogue are directly referenced from data.gov.au or from a server provided by the relevant department or agency. NationalMap does not store any of the data it serves. For example, if you access data relating to broadband availability and quality, you are accessing that data directly from the Department of Communications and the Arts. When you access data relating to surface geology, it is accessed directly from Geoscience Australia. If you access data relating to water, it is typically coming directly from the Bureau of Meteorology. NationalMap itself does not store any data - it provides a map-based view of data that is stored by a growing number of government bodies.
       </p>
 
       <p>You can see details of the department or agency that provides the spatial data by clicking on the title of your prefered data set in the Data Catalogue.</p>

--- a/wwwroot/help/data-workbench.html
+++ b/wwwroot/help/data-workbench.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Help & FAQ - Data Workbench</title>
+    <title>NationalMap - Help & FAQ - Data Workbench</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li class="active"><a href="help.html">Help & FAQ</a></li>
             <li><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -68,11 +68,11 @@
 
         <h4 class="nav-header">How to...</h4>
         <ul class="how-to">
-          <li><a href="help.html">Get started with the National Map</a></li>
+          <li><a href="help.html">Get started with NationalMap</a></li>
           <li><a href="help.html#feature-info">Find out about a displayed feature</a></li>
           <li><a href="help.html#add-data">Display my own spatial data</a></li>
-          <li><a href="help.html#share">Share my National Map view</a></li>
-          <li><a href="help.html#contribute">Contribute Data Sets to the National Map</a></li>
+          <li><a href="help.html#share">Share my NationalMap view</a></li>
+          <li><a href="help.html#contribute">Contribute Data Sets to NationalMap</a></li>
         </ul>
 
         <h4 class="nav-header">Key Features</h4>
@@ -84,8 +84,8 @@
 
         <h4 class="nav-header">Frequently Asked Questions</h4>
         <ul class="faq">
-          <li><a href="faq.html">National Map Operation</a></li>
-          <li><a href="faq.html#nm-systemdata">National Map system and data</a></li>
+          <li><a href="faq.html">NationalMap Operation</a></li>
+          <li><a href="faq.html#nm-systemdata">NationalMap system and data</a></li>
           <li><a href="faq.html#nm-reportingissues">Reporting issues</a></li>
         </ul>
 

--- a/wwwroot/help/faq.html
+++ b/wwwroot/help/faq.html
@@ -234,7 +234,7 @@
     <div id="collapseEight" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingEight">
       <div class="panel-body">
 
-      <p>The spatial data displayed by the NationalMap are all directly referenced from <a href="http://data.gov.au">data.gov.au</a> or from a server provided by the relevant department or agency. The NationalMap does not store any of the data it serves. For example, if you access data relating to broadband availability and quality, you are accessing that data directly from the Department of Communications and the Arts. When you access data relating to surface geology, it is accessed directly from Geoscience Australia. If you access data relating to water, it is typically coming directly from the Bureau of Meteorology. The NationalMap itself does not store any data - it provides a map-based view of data that is stored by a growing number of government bodies.</p>
+      <p>The spatial data displayed by NationalMap are all directly referenced from <a href="http://data.gov.au">data.gov.au</a> or from a server provided by the relevant department or agency. NationalMap does not store any of the data it serves. For example, if you access data relating to broadband availability and quality, you are accessing that data directly from the Department of Communications and the Arts. When you access data relating to surface geology, it is accessed directly from Geoscience Australia. If you access data relating to water, it is typically coming directly from the Bureau of Meteorology. NationalMap itself does not store any data - it provides a map-based view of data that is stored by a growing number of government bodies.</p>
 
       <p>You can see details of the department or agency that provides the spatial data by clicking <strong>About this data</strong> in the Data Workbench.</p>
 
@@ -253,7 +253,7 @@
     <div id="collapseNine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingNine">
       <div class="panel-body">
 
-        <p>The spatial data displayed by NationalMap are referenced directly from the supplying department or agency by the NationalMap server. If that supplying department or agency updates or removes any data, that change will be reflected immediately by the NationalMap.</p>
+        <p>The spatial data displayed by NationalMap are referenced directly from the supplying department or agency by the NationalMap server. If that supplying department or agency updates or removes any data, that change will be reflected immediately by NationalMap.</p>
 
         <p>If you have any questions about the spatial data, you will need to contact the supplying department or agency.</p>
 
@@ -272,7 +272,7 @@
     <div id="collapseTen" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTen">
       <div class="panel-body">
 
-<p>The base maps displayed by the NationalMap come from a number of difference sources including Microsoft’s Bing, Geoscience Australia and NASA. They are downloaded from the source as they are required, so they are as up to date as that service provides.</p>
+<p>The base maps displayed by NationalMap come from a number of difference sources including Microsoft’s Bing, Geoscience Australia and NASA. They are downloaded from the source as they are required, so they are as up to date as that service provides.</p>
 
       </div>
     </div>
@@ -289,7 +289,7 @@
     <div id="collapseEleven" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingEleven">
       <div class="panel-body">
 
-        <p>The NationalMap was developed by <a href="http://www.csiro.au/en/Research/D61">Data61</a> and funded by the Department of Communications and the Arts, and the Department of Prime Minister and Cabinet, working closely with Geoscience Australia. See the <a href="../about.html">About</a> page from more information.</p>
+        <p>NationalMap was developed by <a href="http://www.csiro.au/en/Research/D61">Data61</a> and funded by the Department of Communications and the Arts, and the Department of Prime Minister and Cabinet, working closely with Geoscience Australia. See the <a href="../about.html">About</a> page from more information.</p>
 
       </div>
     </div>
@@ -306,7 +306,7 @@
     <div id="collapseTwelve" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwelve">
       <div class="panel-body">
 
-        <p>Before distributing any data from NationalMap it is important to understand the licence restriction for the data. All Data Sets displayed by the NationalMap are the property of the department or agency which has provided them. Therefore the restrictions for each Data Set may be quite different.</p>
+        <p>Before distributing any data from NationalMap it is important to understand the licence restriction for the data. All Data Sets displayed by NationalMap are the property of the department or agency which has provided them. Therefore the restrictions for each Data Set may be quite different.</p>
 
         <p>The licence which governs the usage and distribution restrictions for each Data Set is shown in the <strong>Info</strong> metadata for the Data Set. To Display this information click on the title of your prefered data set in the Data Catalogue.
 
@@ -318,7 +318,7 @@
     <div class="panel-heading" role="tab" id="headingThirteen">
       <h4 class="panel-title">
         <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThirteen" aria-expanded="false" aria-controls="collapseThirteen">
-          How reliable is the spatial data on the NationalMap?
+          How reliable is the spatial data on NationalMap?
         </a>
       </h4>
     </div>
@@ -361,7 +361,7 @@
 
       <p>Most of the NationalMap base maps are provided by services for the whole world. There is no value in suppressing the display of the rest of the world, so you can view it if you wish. (Take a look at Mt Everest or the Grand Canyon in perspective view - they’re cool!)</p>
 
-      <p>Obviously, the NationalMap’s spatial data does not cover the rest of the world!</p>
+      <p>Obviously, NationalMap’s spatial data does not cover the rest of the world!</p>
 
       </div>
     </div>
@@ -380,7 +380,7 @@
 
       <p>That depends on the supplying departments or agencies, who must make the data available. You will need to contact individual data providers to understand their data release schedules.</p>
 
-      <p>If you are a data provider, see the <a href="help.html#contribute">How To</a> page for information on adding Data Sets to the NationalMap.</p>
+      <p>If you are a data provider, see the <a href="help.html#contribute">How To</a> page for information on adding Data Sets to NationalMap.</p>
 
       </div>
     </div>
@@ -433,7 +433,7 @@
     <div id="collapseNineteen" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingNineteen">
       <div class="panel-body">
 
-    <p>The data displayed by the NationalMap are only referred to by the NationalMap and are not part of the NationalMap. You will need to refer to the department or agency which provides the Data Set which contains the issue.</p>
+    <p>The data displayed by NationalMap are only referred to by NationalMap and are not part of NationalMap. You will need to refer to the department or agency which provides the Data Set which contains the issue.</p>
 
     <p>click on the title of your prefered data set in the Data Catalogue to find out which department or agency provides that data.</p>
 

--- a/wwwroot/help/faq.html
+++ b/wwwroot/help/faq.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Help & FAQ - Frequently Asked Questions</title>
+    <title>NationalMap - Help & FAQ - Frequently Asked Questions</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li class="active"><a href="help.html">Help & FAQ</a></li>
             <li><a href="privacy.html">Privacy</a></li>
-            <li><a href="#launch">Launch the National Map</a></li>
+            <li><a href="#launch">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -68,11 +68,11 @@
 
         <h4 class="nav-header">How to...</h4>
         <ul class="how-to">
-          <li><a href="help.html">Get started with the National Map</a></li>
+          <li><a href="help.html">Get started with NationalMap</a></li>
           <li><a href="help.html#feature-info">Find out about a displayed feature</a></li>
           <li><a href="help.html#add-data">Display my own spatial data</a></li>
-          <li><a href="help.html#share">Share my National Map view</a></li>
-          <li><a href="help.html#contribute">Contribute Data Sets to the National Map</a></li>
+          <li><a href="help.html#share">Share my NationalMap view</a></li>
+          <li><a href="help.html#contribute">Contribute Data Sets to NationalMap</a></li>
         </ul>
 
         <h4 class="nav-header">Key Features</h4>
@@ -84,8 +84,8 @@
 
         <h4 class="nav-header">Frequently Asked Questions</h4>
         <ul class="faq">
-          <li><a href="faq.html">National Map Operation</a></li>
-          <li><a href="faq.html#nm-systemdata">National Map system and data</a></li>
+          <li><a href="faq.html">NationalMap Operation</a></li>
+          <li><a href="faq.html#nm-systemdata">NationalMap system and data</a></li>
           <li><a href="faq.html#nm-reportingissues">Reporting issues</a></li>
         </ul>
 
@@ -110,9 +110,9 @@
       </div>
       <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
         <div class="panel-body">
-        <p>There isn't one! All user interface features of the NationalMap are either obvious from the interface or are described in this Help.</p>
+        <p>There isn't one! All user interface features of NationalMap are either obvious from the interface or are described in this Help.</p>
 
-        <p>The NationalMap has been carefully designed to be as easy to use as possible. Our user experience design team run regular usability testing sessions, the results of which are then assessed for inclusion in releases.</p>
+        <p>NationalMap has been carefully designed to be as easy to use as possible. Our user experience design team run regular usability testing sessions, the results of which are then assessed for inclusion in releases.</p>
       </div>
     </div>
   </div>
@@ -144,7 +144,7 @@
     <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
       <div class="panel-body">
 
-      <p>There are three types of spatial data which are read from the data sources and displayed by the NationalMap over its base maps:</p>
+      <p>There are three types of spatial data which are read from the data sources and displayed by NationalMap over its base maps:</p>
       <p><strong>Point Click</strong> on any point to see more information about that particular point feature.</p>
       <p><strong>Line Click</strong> on any line to see more information about that particular line feature.</p>
       <p><strong>Region Click</strong> within any region to see more information about that region.</p>

--- a/wwwroot/help/help.html
+++ b/wwwroot/help/help.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Help & FAQ</title>
+    <title>NationalMap - Help & FAQ</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li class="active"><a href="help.html">Help & FAQ</a></li>
             <li><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -68,11 +68,11 @@
 
         <h4 class="nav-header">How to...</h4>
         <ul class="how-to">
-          <li><a href="help.html">Get started with the National Map</a></li>
+          <li><a href="help.html">Get started with NationalMap</a></li>
           <li><a href="help.html#feature-info">Find out about a displayed feature</a></li>
           <li><a href="help.html#add-data">Display my own spatial data</a></li>
-          <li><a href="help.html#share">Share my National Map view</a></li>
-          <li><a href="help.html#contribute">Contribute Data Sets to the National Map</a></li>
+          <li><a href="help.html#share">Share my NationalMap view</a></li>
+          <li><a href="help.html#contribute">Contribute Data Sets to NationalMap</a></li>
         </ul>
 
         <h4 class="nav-header">Key Features</h4>
@@ -84,8 +84,8 @@
 
         <h4 class="nav-header">Frequently Asked Questions</h4>
         <ul class="faq">
-          <li><a href="faq.html">National Map Operation</a></li>
-          <li><a href="faq.html#nm-systemdata">National Map system and data</a></li>
+          <li><a href="faq.html">NationalMap Operation</a></li>
+          <li><a href="faq.html#nm-systemdata">NationalMap system and data</a></li>
           <li><a href="faq.html#nm-reportingissues">Reporting issues</a></li>
         </ul>
 
@@ -102,12 +102,12 @@
       <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/2E-u0gjz9Yw"></iframe>
     </div>
 
-    <h2><a class="anchor" name="getting-started">How to get started with the National Map</a></h2>
+    <h2><a class="anchor" name="getting-started">How to get started with NationalMap</a></h2>
 
-    <p>To launch the National Map and display some basic data follow these steps.</p>
+    <p>To launch NationalMap and display some basic data follow these steps.</p>
 
     <ul>
-      <li>Display the NationalMap by using the URL <a href="http://nationalmap.gov.au">http://nationalmap.gov.au</a>.</li>
+      <li>Display NationalMap by using the URL <a href="http://nationalmap.gov.au">http://nationalmap.gov.au</a>.</li>
       <li>In the left hand panel click the <strong>Add Data</strong> button to launch the Data Catalogue.</li>
       <li>Browse through the Data Catalogue to find a data set of interest. Click on the title of your prefered data set to get a preview of that data, along with a description and other relevent metadata. To view your selected data set on a larger map, click the <strong>Add to the Map</strong> button. The spatial data will be immediately displayed in the map view, and a visual legend for that data will appear in the Data Workbench, located on the left hand side of the page.</li>
       <li>Note that it may not be immediately obvious where your selected spatial data has loaded on the map if does not cover a large part of Australia. To locate loaded data on the map, go to the Data Workbench (positioned on the left hand side of the page), and click the <strong>Zoom to extent</strong> link for your desired data set. From here you can also click <strong>About this data</strong> to get more information about your selected data set.</li>
@@ -131,7 +131,7 @@
 
     <h2><a class="anchor" name="add-data">How to display my own spreadsheet or spatial data</a></h2>
 
-    <p>National Map can display two kinds of spreadsheets:<p>
+    <p>NationalMap can display two kinds of spreadsheets:<p>
     <ol><li>Spreadsheets with a <strong>point location (latitude and longitude)</strong> for each row, expressed as two columns: <code>lat</code> and <code>lon</code>. These will be displayed as points (circles).</li>
     <li>Spreadsheets where each row refers to a <strong>region</strong> such as a local government area (council), state, postcode, or ABS statistical unit such as an SA2 or CED (Commonwealth Electoral Division). Columns must be named according to the <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">CSV-geo-au</a> standard. These will be displayed as regions, highlighting the actual shape of each area.</li>
     </ol>
@@ -142,7 +142,7 @@
     <p>There are two ways to load your data:</p>
 
     <ul>
-    <li>Drag your data file onto the NationalMap map view. The format of the data file will be auto-detected.</li>
+    <li>Drag your data file onto NationalMap map view. The format of the data file will be auto-detected.</li>
     <li>Click on the <strong>Add Data</strong> button in the left hand panel. This will launch the Data Catalogue. Select the <strong>My Data</strong> tab at the top of the modal window and follow the provided instructions.</li>
     </ul>
 
@@ -152,7 +152,7 @@
     <p>To share a view of your data with others, you must first publish it to the web somewhere with a URL, and then load it from there.</p>
 
 
-    <h2><a class="anchor" name="share">How to share my National Map view with others</a></h2>
+    <h2><a class="anchor" name="share">How to share my NationalMap view with others</a></h2>
 
     <p>There are three ways:</p>
 
@@ -165,12 +165,12 @@
     <p><strong>Note that only the third method will show the data you have loaded from a local file</strong>.</p>
 
 
-    <h2><a class="anchor" name="contribute">How to contribute Data Sets to National Map</a></h2>
+    <h2><a class="anchor" name="contribute">How to contribute Data Sets to NationalMap</a></h2>
 
-    <p>The NationalMap encourages data providers to publish their spatial data using this platform. There are two routes you can take to publishing.</p>
+    <p>NationalMap encourages data providers to publish their spatial data using this platform. There are two routes you can take to publishing.</p>
 
     <ul>
-      <li><p>Any spatial data which is added to <a href="http://data.gov.au">data.gov.au</a> using a protocol or format supported by the NationalMap (such as WMS) will automatically appear in the <strong>data.gov.au</strong> section of the <strong>Data Catalogue</strong> tab for the NationalMap. See WMS Data Sets for a list of spatial data sets already on <a href="http://data.gov.au">data.gov.au</a>. See the <a href="https://toolkit.data.gov.au/index.php?title=How_to_use_data.gov.au">data.gov.au Toolkit</a> for a detailed reference on using <a href="http://data.gov.au">data.gov.au</a> and using it to publish your own data sets.</p></li>
+      <li><p>Any spatial data which is added to <a href="http://data.gov.au">data.gov.au</a> using a protocol or format supported by NationalMap (such as WMS) will automatically appear in the <strong>data.gov.au</strong> section of the <strong>Data Catalogue</strong> tab for NationalMap. See WMS Data Sets for a list of spatial data sets already on <a href="http://data.gov.au">data.gov.au</a>. See the <a href="https://toolkit.data.gov.au/index.php?title=How_to_use_data.gov.au">data.gov.au Toolkit</a> for a detailed reference on using <a href="http://data.gov.au">data.gov.au</a> and using it to publish your own data sets.</p></li>
       <li><p>If you require your data set to appear under a separate category of the NationalMap Data Catalogue, you will need to contact the support for NationalMap by emailing to <a href="mailto:data@pmc.gov.au">data@pmc.gov.au</a> for more information. You will need to provide an internet accessible service in a standard protocol to access your data set on the internet and appropriate references must be added to the NationalMap configuration.</p></li>
     </ul>
 

--- a/wwwroot/help/help.html
+++ b/wwwroot/help/help.html
@@ -133,7 +133,7 @@
 
     <p>NationalMap can display two kinds of spreadsheets:<p>
     <ol><li>Spreadsheets with a <strong>point location (latitude and longitude)</strong> for each row, expressed as two columns: <code>lat</code> and <code>lon</code>. These will be displayed as points (circles).</li>
-    <li>Spreadsheets where each row refers to a <strong>region</strong> such as a local government area (council), state, postcode, or ABS statistical unit such as an SA2 or CED (Commonwealth Electoral Division). Columns must be named according to the <a href="https://github.com/NICTA/nationalmap/wiki/csv-geo-au">CSV-geo-au</a> standard. These will be displayed as regions, highlighting the actual shape of each area.</li>
+    <li>Spreadsheets where each row refers to a <strong>region</strong> such as a local government area (council), state, postcode, or ABS statistical unit such as an SA2 or CED (Commonwealth Electoral Division). Columns must be named according to the <a href="https://github.com/TerriaJS/nationalmap/wiki/csv-geo-au">CSV-geo-au</a> standard. These will be displayed as regions, highlighting the actual shape of each area.</li>
     </ol>
     <p>Spreadsheets must be saved as CSV (comma-separated values). </p>
 

--- a/wwwroot/help/map-navigation.html
+++ b/wwwroot/help/map-navigation.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Help & FAQ - Map Navigation and Display</title>
+    <title>NationalMap - Help & FAQ - Map Navigation and Display</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li class="active"><a href="help.html">Help & FAQ</a></li>
             <li><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -68,11 +68,11 @@
 
         <h4 class="nav-header">How to...</h4>
         <ul class="how-to">
-          <li><a href="help.html">Get started with the National Map</a></li>
+          <li><a href="help.html">Get started with NationalMap</a></li>
           <li><a href="help.html#feature-info">Find out about a displayed feature</a></li>
           <li><a href="help.html#add-data">Display my own spatial data</a></li>
-          <li><a href="help.html#share">Share my National Map view</a></li>
-          <li><a href="help.html#contribute">Contribute Data Sets to the National Map</a></li>
+          <li><a href="help.html#share">Share my NationalMap view</a></li>
+          <li><a href="help.html#contribute">Contribute Data Sets to NationalMap</a></li>
         </ul>
 
         <h4 class="nav-header">Key Features</h4>
@@ -84,8 +84,8 @@
 
         <h4 class="nav-header">Frequently Asked Questions</h4>
         <ul class="faq">
-          <li><a href="faq.html">National Map Operation</a></li>
-          <li><a href="faq.html#nm-systemdata">National Map system and data</a></li>
+          <li><a href="faq.html">NationalMap Operation</a></li>
+          <li><a href="faq.html#nm-systemdata">NationalMap system and data</a></li>
           <li><a href="faq.html#nm-reportingissues">Reporting issues</a></li>
         </ul>
 

--- a/wwwroot/help/privacy.html
+++ b/wwwroot/help/privacy.html
@@ -9,7 +9,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>The National Map - Privacy</title>
+    <title>NationalMap - Privacy</title>
 
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -49,10 +49,10 @@
         </div>
         <div id="navbar" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
-            <li><a href="../about.html">About the National Map</a></li>
+            <li><a href="../about.html">About NationalMap</a></li>
             <li><a href="help.html">Help & FAQ</a></li>
             <li class="active"><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au" target="blank">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au" target="blank">Launch NationalMap</a></li>
           </ul>
         </div><!--/.nav-collapse -->
       </div>
@@ -109,7 +109,7 @@
 
       <p>We use the information we collect from your browsing of this website for statistical analysis, system administration, monitoring of this website’s security, customisation of this website to users’ needs, and the evaluation, research and development of this website.</p>
 
-            <p>In order to give you a better experience, we use a URL shortening service provided by a third party. That service may also track the clicks and referrers (sharers) of the NationalMap.</p>
+            <p>In order to give you a better experience, we use a URL shortening service provided by a third party. That service may also track the clicks and referrers (sharers) of NationalMap.</p>
 
       <p>No attempt will be made to identify users due to their browsing activities on this website, except in the unlikely event of an investigation, for example, where a law enforcement agency may exercise a warrant or subpoena. The information we collect from your browsing of this website will only be disclosed to a third party if it is required or authorised by law.</p>
 
@@ -125,7 +125,7 @@
 
       <h2>Online forms, email address and contact us</h2>
 
-      <p>When using this website (for example, the online forms or contact us function), you may provide us with your personal information, for example, your name and email address etc. When you do this, you agree to provide us with your consent to disclose your personal information to other areas of the Department and potentially other appropriate third parties, for example, the National ICT Australia, Geoscience Australia, Bureau of Meteorology, Australian Bureau of Statistics, data.gov.au website etc. so that we can appropriately respond to your request or query. You also agree to provide us with your consent to disclose your personal information for the administration, regulation and evaluation processes associated with this website or for related purposes such as any policy development associated with this website.</p>
+      <p>When using this website (for example, the online forms or contact us function), you may provide us with your personal information, for example, your name and email address etc. When you do this, you agree to provide us with your consent to disclose your personal information to other areas of the Department and potentially other appropriate third parties, for example, National ICT Australia, Geoscience Australia, Bureau of Meteorology, Australian Bureau of Statistics, data.gov.au website etc. so that we can appropriately respond to your request or query. You also agree to provide us with your consent to disclose your personal information for the administration, regulation and evaluation processes associated with this website or for related purposes such as any policy development associated with this website.</p>
 
       <p>You have the right not to identify yourself or to use an alias (pseudonym) when you contact us or use online forms in relation to this website. However, where it is impractical for us to deal with your request in that way, or the law requires or authorise us to collect your personal information, then we may require you to identify yourself.</p>
 

--- a/wwwroot/privacy.html
+++ b/wwwroot/privacy.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>The NationalMap</title>
+        <title>NationalMap</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="public/css/bootstrap.min.css" rel="stylesheet" type="text/css" media="all"/>
         <link href="public/css/custom.css" rel="stylesheet" type="text/css" media="all"/>
@@ -33,10 +33,10 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
-            <li><a href="about.html">About National Map</a></li>
+            <li><a href="about.html">About NationalMap</a></li>
             <li><a href="help/howto.html">Help & FAQ</a></li>
             <li class="active"><a href="privacy.html">Privacy</a></li>
-            <li><a href="http://nationalmap.gov.au">Launch the National Map</a></li>
+            <li><a href="http://nationalmap.gov.au">Launch NationalMap</a></li>
         </ul>
 
         </div>
@@ -97,7 +97,7 @@
 
 			<p>We use the information we collect from your browsing of this website for statistical analysis, system administration, monitoring of this website’s security, customisation of this website to users’ needs, and the evaluation, research and development of this website.</p>
 
-            <p>In order to give you a better experience, we use a URL shortening service provided by a third party. That service may also track the clicks and referrers (sharers) of the NationalMap.</p>
+            <p>In order to give you a better experience, we use a URL shortening service provided by a third party. That service may also track the clicks and referrers (sharers) of NationalMap.</p>
 
 			<p>No attempt will be made to identify users due to their browsing activities on this website, except in the unlikely event of an investigation, for example, where a law enforcement agency may exercise a warrant or subpoena. The information we collect from your browsing of this website will only be disclosed to a third party if it is required or authorised by law.</p>
 
@@ -113,7 +113,7 @@
 
 			<h2>Online forms, email address and contact us</h2>
 
-			<p>When using this website (for example, the online forms or contact us function), you may provide us with your personal information, for example, your name and email address etc. When you do this, you agree to provide us with your consent to disclose your personal information to other areas of the Department and potentially other appropriate third parties, for example, the National ICT Australia, Geoscience Australia, Bureau of Meteorology, Australian Bureau of Statistics, data.gov.au website etc. so that we can appropriately respond to your request or query. You also agree to provide us with your consent to disclose your personal information for the administration, regulation and evaluation processes associated with this website or for related purposes such as any policy development associated with this website.</p>
+			<p>When using this website (for example, the online forms or contact us function), you may provide us with your personal information, for example, your name and email address etc. When you do this, you agree to provide us with your consent to disclose your personal information to other areas of the Department and potentially other appropriate third parties, for example, National ICT Australia, Geoscience Australia, Bureau of Meteorology, Australian Bureau of Statistics, data.gov.au website etc. so that we can appropriately respond to your request or query. You also agree to provide us with your consent to disclose your personal information for the administration, regulation and evaluation processes associated with this website or for related purposes such as any policy development associated with this website.</p>
 
 			<p>You have the right not to identify yourself or to use an alias (pseudonym) when you contact us or use online forms in relation to this website. However, where it is impractical for us to deal with your request in that way, or the law requires or authorise us to collect your personal information, then we may require you to identify yourself.</p>
 


### PR DESCRIPTION
The references to NationalMap are inconsistent.  This PR removes all usages of **The** in front of NationalMap, and replaces "National Map" with NationalMap (no space).  There is also an old link to csv-geo-au I've replaced.