### PR TITLE
Use 2017-02-23 version of the private server config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "awsEc2InstanceType": "t2.medium",
     "awsEc2ImageId": "ami-2a644649",
     "awsKeyName": "natmap-kring",
-    "awsS3ServerConfigOverridePath": "s3://nationalmap-apps/nationalmap/privateserverconfig-2016-07-14.json",
+    "awsS3ServerConfigOverridePath": "s3://nationalmap-apps/nationalmap/privateserverconfig-2017-02-23.json",
     "awsS3ClientConfigOverridePath": "s3://nationalmap-apps/nationalmap/privateclientconfig-2017-02-15.json",
     "northernAustraliaPath": "../NorthernAustralia"
   },


### PR DESCRIPTION
The only change in this version is that `trustProxy` has been set to `"loopback, linklocal, uniquelocal"`, which should help prevent internal network IPs from showing up in feedback issues.