### PR TITLE
Add biogas server to proxy list for northernaustralia

### DIFF
--- a/devserverconfig.json
+++ b/devserverconfig.json
@@ -23,7 +23,8 @@
         "lakemac.com.au",
         "data.aodn.org.au",
         "adelaidemetro.com.au",
-        "tern.org.au"
+        "tern.org.au",
+        "biogas.nceastg.usq.edu.au"
     ],
     "initPaths": [
         "node_modules/nationalmap-catalog/build"


### PR DESCRIPTION
Add server to proxy list for northernaustralia biogas datasets.

See TerriaJS/NorthernAustralia#79.