### PR TITLE
added AWS managed SSM policy to instance role profile

### DIFF
--- a/deploy/aws/stack.json
+++ b/deploy/aws/stack.json
@@ -303,6 +303,9 @@
           ]
         },
         "Path": "/",
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        ],
         "Policies": [
           {
             "PolicyDocument": {


### PR DESCRIPTION
Updates NationalMap cloudformation stacks to include the AWS managed SSM policy. enabling inventory management and potential for automatic patching.