### PR TITLE
Get imagery from Bing, not Ion

### DIFF
--- a/wwwroot/config.json
+++ b/wwwroot/config.json
@@ -156,7 +156,6 @@
       "trainerHeight": "64",
       "workbenchWidth": "350"
     },
-    "useCesiumIonBingImagery": true,
     "welcomeMessageVideo": {
       "placeholderImage": "https://img.youtube.com/vi/C4-gLv09Rfo/maxresdefault.jpg",
       "videoTitle": "Getting started with the map",


### PR DESCRIPTION
A recent config change inadvertently configured National Map to get imagery from Ion instead of Bing. This PR reverts that change.