### PR TITLE
Upgrade to NodeJS 14

### DIFF
--- a/deploy/aws/user-data
+++ b/deploy/aws/user-data
@@ -2,7 +2,11 @@
 
 # update and install packages, reboot if necessary
 package_update: true
-package_upgrade: true
+package_upgrade: false
+
+apt_sources:
+  - source: deb https://deb.nodesource.com/node_14.x bionic main
+    keyid: 1655a0ab68576280
 
 packages:
  - awscli

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "awsS3PackagesPath": "s3://nationalmap-apps/nationalmap",
     "awsRegion": "ap-southeast-2",
     "awsEc2InstanceType": "t3.small",
-    "awsEc2ImageId": "ami-073dec7083f398e0a",
+    "awsEc2ImageId": "ami-02ce965e844c396fc",
     "awsKeyName": "has100",
     "awsS3ServerConfigOverridePath": "s3://nationalmap-apps/nationalmap/privateserverconfig-2021-12-23.json",
     "awsS3ClientConfigOverridePath": "s3://nationalmap-apps/nationalmap/privateclientconfig-2021-12-23.json"


### PR DESCRIPTION
`package_upgrade` is no longer required with SSM and is disabled to prevent a race condition with the nodesource repository update.